### PR TITLE
fix(ansible): increase inotify and file descriptor limits for Kubernetes

### DIFF
--- a/ansible/requirements.yaml
+++ b/ansible/requirements.yaml
@@ -4,6 +4,10 @@ collections:
     version: 6.1.0
   - name: ansible.utils
     version: 6.0.0
+  - name: ansible.posix
+    version: 1.6.2
+  - name: community.general
+    version: 10.3.1
 roles:
   - name: xanmanning.k3s
     version: v3.6.1

--- a/ansible/roles/prep/tasks/main.yaml
+++ b/ansible/roles/prep/tasks/main.yaml
@@ -42,3 +42,25 @@
     state: stopped
     masked: true
   when: disable_multipath
+- name: Configure inotify limits for Kubernetes
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    sysctl_set: true
+    reload: true
+  loop:
+    - { name: 'fs.inotify.max_user_watches', value: '524288' }
+    - { name: 'fs.inotify.max_user_instances', value: '512' }
+    - { name: 'fs.file-max', value: '2097152' }
+- name: Configure file descriptor limits
+  community.general.pam_limits:
+    domain: '*'
+    limit_type: "{{ item.limit_type }}"
+    limit_item: "{{ item.limit_item }}"
+    value: "{{ item.value }}"
+  loop:
+    - { limit_type: 'soft', limit_item: 'nofile', value: '65536' }
+    - { limit_type: 'hard', limit_item: 'nofile', value: '65536' }
+    - { limit_type: 'soft', limit_item: 'nproc', value: '65536' }
+    - { limit_type: 'hard', limit_item: 'nproc', value: '65536' }


### PR DESCRIPTION
Add system-level configuration to prevent "too many open files" errors when using kubectl logs and other file-watching operations.

Changes:
- Configure fs.inotify.max_user_watches to 524288 (from default 8192)
- Configure fs.inotify.max_user_instances to 512 (from default 128)
- Configure fs.file-max to 2097152 for system-wide file descriptors
- Set nofile limits to 65536 (soft and hard) per process
- Set nproc limits to 65536 (soft and hard) per user
- Add ansible.posix and community.general collections to requirements

These values follow official Kubernetes SIG recommendations and are appropriate for production clusters with high pod density.

Resolves: "failed to create fsnotify watcher: too many open files"